### PR TITLE
change domain used for staging

### DIFF
--- a/docs/Deploy.md
+++ b/docs/Deploy.md
@@ -57,11 +57,11 @@ TODO show example
 
 ## Ingresses
 
-Ingresses are used when you want to expose a service to the public by an endpoint. Please note that Etimo Kubernetes has a custom policy in place for ingresses at the moment that restrict projects to only use hostnames in the form of `<project>.<cluster>.<domain>` or `<project>-<something>.<cluster>.<domain>`. You can for example use `myproject.staging.etimo-test.live` or `myproject-test.staging.etimo-test.live`. This is to prevent havoc among ingresses and to naturally tie them to the projects that owns them. Otherwise you will get an error similar to this one:
+Ingresses are used when you want to expose a service to the public by an endpoint. Please note that Etimo Kubernetes has a custom policy in place for ingresses at the moment that restrict projects to only use hostnames in the form of `<project>.<cluster>.<domain>` or `<project>-<something>.<cluster>.<domain>`. You can for example use `myproject.app.etimo.se` or `myproject-test.app.etimo.se`. This is to prevent havoc among ingresses and to naturally tie them to the projects that owns them. Otherwise you will get an error similar to this one:
 
 ```bash
 $ kubectl apply -f invalid-ingress.yaml
-Error from server: error when creating "invalid-ingress.yaml": admission webhook "admission-server.default.svc" denied the request: ingress host must be default.staging.etimo-test.live or default-<something>.staging.etimo-test.live
+Error from server: error when creating "invalid-ingress.yaml": admission webhook "admission-server.default.svc" denied the request: ingress host must be default.app.etimo.se or default-<something>.app.etimo.se
 ```
 
 ## <a name='how-to-verify-deployment'></a>How to verify deployment

--- a/docs/Deploy.md
+++ b/docs/Deploy.md
@@ -57,11 +57,11 @@ TODO show example
 
 ## Ingresses
 
-Ingresses are used when you want to expose a service to the public by an endpoint. Please note that Etimo Kubernetes has a custom policy in place for ingresses at the moment that restrict projects to only use hostnames in the form of `<project>.<cluster>.<domain>` or `<project>-<something>.<cluster>.<domain>`. You can for example use `myproject.app.etimo.se` or `myproject-test.app.etimo.se`. This is to prevent havoc among ingresses and to naturally tie them to the projects that owns them. Otherwise you will get an error similar to this one:
+Ingresses are used when you want to expose a service to the public by an endpoint. Please note that Etimo Kubernetes has a custom policy in place for ingresses at the moment that restrict projects to only use hostnames in the form of `<project>.<cluster>.<domain>` or `<project>-<something>.<cluster>.<domain>`. You can for example use `myproject.k8s.etimo.se` or `myproject-test.k8s.etimo.se`. This is to prevent havoc among ingresses and to naturally tie them to the projects that owns them. Otherwise you will get an error similar to this one:
 
 ```bash
 $ kubectl apply -f invalid-ingress.yaml
-Error from server: error when creating "invalid-ingress.yaml": admission webhook "admission-server.default.svc" denied the request: ingress host must be default.app.etimo.se or default-<something>.app.etimo.se
+Error from server: error when creating "invalid-ingress.yaml": admission webhook "admission-server.default.svc" denied the request: ingress host must be default.k8s.etimo.se or default-<something>.k8s.etimo.se
 ```
 
 ## <a name='how-to-verify-deployment'></a>How to verify deployment

--- a/kubernetes/infra/certificate.yaml
+++ b/kubernetes/infra/certificate.yaml
@@ -7,9 +7,9 @@ spec:
   issuerRef:
     name: le-staging-wildcard-issuer
     kind: ClusterIssuer
-  commonName: "*.app.etimo.se"
+  commonName: "*.k8s.etimo.se"
   dnsNames:
-    - "*.app.etimo.se"
+    - "*.k8s.etimo.se"
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/kubernetes/infra/certificate.yaml
+++ b/kubernetes/infra/certificate.yaml
@@ -7,9 +7,9 @@ spec:
   issuerRef:
     name: le-staging-wildcard-issuer
     kind: ClusterIssuer
-  commonName: "*.staging.etimo-test.live"
+  commonName: "*.app.etimo.se"
   dnsNames:
-    - "*.staging.etimo-test.live"
+    - "*.app.etimo.se"
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer

--- a/kubernetes/infra/lb.yaml
+++ b/kubernetes/infra/lb.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
-    service.beta.kubernetes.io/do-loadbalancer-hostname: "staging.etimo-test.live"
+    service.beta.kubernetes.io/do-loadbalancer-hostname: "app.etimo.se"
   name: ingress-nginx-controller-staging
   namespace: ingress-nginx
 spec:

--- a/kubernetes/infra/lb.yaml
+++ b/kubernetes/infra/lb.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   annotations:
     service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: "true"
-    service.beta.kubernetes.io/do-loadbalancer-hostname: "app.etimo.se"
+    service.beta.kubernetes.io/do-loadbalancer-hostname: "k8s.etimo.se"
   name: ingress-nginx-controller-staging
   namespace: ingress-nginx
 spec:


### PR DESCRIPTION
this is just a search and replace for staging.etimo-test.live to app.etimo.se

This also removes the staging part of the domain name but i don't think we need to have a staging and a live cluster for what we are using this cluster for. This should be cleaned up a bit in the future aswell but this is a quick fix for now to get something working.